### PR TITLE
Fix #1

### DIFF
--- a/src/main/java/io/github/apace100/wwfix/FluidStateHelper.java
+++ b/src/main/java/io/github/apace100/wwfix/FluidStateHelper.java
@@ -1,0 +1,23 @@
+package io.github.apace100.wwfix;
+
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.WorldView;
+import net.minecraft.world.chunk.Chunk;
+
+public class FluidStateHelper {
+
+    public static FluidState getFluidState(BlockView world, BlockPos pos) {
+        if (world.isOutOfHeightLimit(pos)) {
+            return Fluids.EMPTY.getDefaultState();
+        } else {
+            if (world instanceof WorldView worldView) {
+                Chunk chunk = worldView.getChunk(pos);
+                return chunk.getFluidState(pos);
+            }
+            return world.getFluidState(pos);
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/wwfix/mixin/FluidloggedWalkMixin.java
+++ b/src/main/java/io/github/apace100/wwfix/mixin/FluidloggedWalkMixin.java
@@ -1,6 +1,7 @@
 package io.github.apace100.wwfix.mixin;
 
 import io.github.apace100.wwfix.FluidShapes;
+import io.github.apace100.wwfix.FluidStateHelper;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.fluid.FluidState;
@@ -8,6 +9,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,7 +21,10 @@ public class FluidloggedWalkMixin {
 
     @Inject(method = "getCollisionShape(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/ShapeContext;)Lnet/minecraft/util/shape/VoxelShape;", at = @At("RETURN"), cancellable = true)
     private void wwfix$fixFluidloggedCollisionShape(BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
-        FluidState fluidState = world.getFluidState(pos);
+        FluidState fluidState = FluidStateHelper.getFluidState(world, pos);
+        if (fluidState == null) {
+            return;
+        }
         int level = fluidState.getLevel();
         if(level == 0) {
             return;
@@ -26,7 +32,7 @@ public class FluidloggedWalkMixin {
         VoxelShape shape = FluidShapes.VOXEL_SHAPES[level];
         VoxelShape shapeBelow = FluidShapes.VOXEL_SHAPES[level - 1];
         if (context.isAbove(shapeBelow, pos, true)
-                && context.canWalkOnFluid(world.getFluidState(pos.up()), fluidState)) {
+                && context.canWalkOnFluid(FluidStateHelper.getFluidState(world, pos.up()), fluidState)) {
             VoxelShape original = cir.getReturnValue();
             cir.setReturnValue(VoxelShapes.union(original, shape));
         }


### PR DESCRIPTION
Fixed #1 by using a custom implementation of `BlockView#getFluidState`, which should be safe when using non WorldChunks, such as Flywheel's VirtualChunk.

There's also an added nullcheck as VirtualChunk has its getFluidState value as null.